### PR TITLE
Use `rc` instead of `npmconf`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,2 @@
 'use strict';
-var npmconf = require('npmconf');
-
-module.exports = function (cb) {
-	npmconf.load(function (err, conf) {
-		if (err) {
-			cb(err);
-			return;
-		}
-
-		cb(null, conf.get('registry'));
-	});
-};
+module.exports = require('rc')('npm').registry || 'http://registry.npmjs.org/';

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "url"
   ],
   "dependencies": {
-    "npmconf": "^2.0.1"
+    "rc": "^0.5.1"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "*",
+    "require-uncached": "^1.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,12 +1,20 @@
 'use strict';
 var assert = require('assert');
-var registryUrl = require('./');
+var fs = require('fs');
+var requireUncached = require('require-uncached');
 
-it('should get the npm registry URL from the npm config', function (cb) {
-	registryUrl(function (err, url) {
-		console.log('Registry URL:', url);
+it('should get the npm registry URL globally', function () {
+	assert(requireUncached('./').length);
+});
+
+it('should get the npm registry URL locally', function (cb) {
+	fs.writeFile('.npmrc', 'registry=http://registry.npmjs.eu/', function (err) {
 		assert(!err, err);
-		assert(url.length > 0);
-		cb();
+		assert(requireUncached('./') === 'http://registry.npmjs.eu/');
+
+		fs.unlink('.npmrc', function (err) {
+			assert(!err, err);
+			cb();
+		});
 	});
 });


### PR DESCRIPTION
Need to require it on the go in tests otherways it'll store the first loaded one. Addresses https://github.com/npm/npm/issues/6397.
