### PR TITLE
feat(scope): add support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,6 @@
 'use strict';
-module.exports = require('rc')('npm').registry || 'https://registry.npmjs.org/';
+module.exports = function (scope) {
+	var rc = require('rc')('npm');
+	return rc[scope + ':registry'] ||
+		rc.registry || 'https://registry.npmjs.org/';
+};

--- a/readme.md
+++ b/readme.md
@@ -22,11 +22,27 @@ registry = 'https://custom-registry.com/'
 ```
 
 ```js
-var registryUrl = require('registry-url');
+var registryUrl = require('registry-url')();
 
 console.log(registryUrl);
 //=> https://custom-registry.com/
 ```
+
+It can also retrieve the registry URL associated with an [npm scope](https://docs.npmjs.com/misc/scope).
+
+```ini
+# .npmrc
+@myco:registry = 'https://custom-registry.com/'
+```
+
+```js
+var registryScopeUrl = require('registry-url')('@myco');
+
+console.log(registryScopeUrl);
+//=> https://custom-registry.com/
+```
+
+If the provided scope is not in the user's `.npmrc` file, then `registry-url` will check for the existence of `registry`, or if that's not set, fallback to the default npm registry.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -4,13 +4,37 @@ var fs = require('fs');
 var requireUncached = require('require-uncached');
 
 it('should get the npm registry URL globally', function () {
-	assert(requireUncached('./').length);
+	assert(requireUncached('./')().length);
 });
 
 it('should get the npm registry URL locally', function (cb) {
 	fs.writeFile('.npmrc', 'registry=http://registry.npmjs.eu/', function (err) {
 		assert(!err, err);
-		assert(requireUncached('./') === 'http://registry.npmjs.eu/');
+		assert(requireUncached('./')() === 'http://registry.npmjs.eu/');
+
+		fs.unlink('.npmrc', function (err) {
+			assert(!err, err);
+			cb();
+		});
+	});
+});
+
+it('should return local scope registry URL', function (cb) {
+	fs.writeFile('.npmrc', '@myco:registry=http://reg.example.com/', function (err) {
+		assert(!err, err);
+		assert(requireUncached('./')('@myco') === 'http://reg.example.com/');
+
+		fs.unlink('.npmrc', function (err) {
+			assert(!err, err);
+			cb();
+		});
+	});
+});
+
+it('should return default npm registry when scope registry not set', function (cb) {
+	fs.writeFile('.npmrc', '', function (err) {
+		assert(!err, err);
+		assert(requireUncached('./')('@invalidScope') === 'https://registry.npmjs.org/');
 
 		fs.unlink('.npmrc', function (err) {
 			assert(!err, err);


### PR DESCRIPTION
Add support for retrieving a URL from a user's `.npmrc` file that is
associated with an [npm scope](https://docs.npmjs.com/misc/scope).