### PR TITLE
Make this module browserifiable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 module.exports = function (scope) {
-	var rc = require('rc')('npm');
-	return rc[scope + ':registry'] ||
-		rc.registry || 'https://registry.npmjs.org/';
+	var rc = require('rc')('npm', {registry: 'https://registry.npmjs.org/'});
+	return rc[scope + ':registry'] || rc.registry;
 };


### PR DESCRIPTION
With browserify I get a TypeError because `rc` simply returns the defaults in the browser (and this module provides no defaults).

```js
module.exports = function (name, defaults) {
  return defaults
}
```

The fix is very simple.