### PR TITLE
Detect npm_config_registry from the environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = scope => {
 	const rc = require('rc')('npm', {registry: 'https://registry.npmjs.org/'});
-	const url = rc[scope + ':registry'] || rc.registry;
+	const url = rc[scope + ':registry'] || rc.config_registry || rc.registry;
 	return url.slice(-1) === '/' ? url : url + '/';
 };

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ import importFresh from 'import-fresh';
 
 const fsP = pify(fs);
 
+delete process.env.npm_config_registry;
 test.afterEach(async () => {
 	try {
 		await fsP.unlink('.npmrc');
@@ -13,6 +14,13 @@ test.afterEach(async () => {
 
 test('get the npm registry URL globally', t => {
 	t.truthy(importFresh('.')().length);
+});
+
+test('works with npm_config_registry in the environment', t => {
+	// eslint-disable-next-line camelcase
+	process.env.npm_config_registry = 'http://registry.example';
+	t.is(importFresh('.')(), 'http://registry.example/');
+	delete process.env.npm_config_registry;
 });
 
 test('get the npm registry URL locally', async t => {


### PR DESCRIPTION
I found that update-notifier didn't work for me because my private registry is only configured in the environment (as I have a direnv script that detects if I'm connected to our vpn or not and updates my environment appropriately).

Since NPM's usage of environment variable naming isn't quite compatible with the way rc uses them, it needs a little tweak..