### PR TITLE
Fix broken URL in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Get the set npm registry URL
 
-It's usually `https://registry.npmjs.org/`, but [configurable](https://www.npmjs.org/doc/misc/npm-config.html#registry).
+It's usually `https://registry.npmjs.org/`, but [configurable](https://docs.npmjs.com/misc/registry).
 
 Use this if you do anything with the npm registry as users will expect it to use their configured registry.
 


### PR DESCRIPTION
https://www.npmjs.org/doc/misc/npm-config.html#registry has been changed to https://docs.npmjs.com/misc/registry