### PR TITLE
Update `rc` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "scope"
   ],
   "dependencies": {
-    "rc": "^1.0.1"
+    "rc": "^1.2.7"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
Until version `1.2.7` `rc` contain minor level vulnerability described [here](https://nodesecurity.io/advisories/612).

Basically this is due to, it was dependent on `deep-extend` module.